### PR TITLE
[FEAT]: 어드민 대시보드 사이드 바 컴포넌트 및 어드민 라우팅 경로 구성

### DIFF
--- a/src/app/admin/(with-sidebar)/application-form/page.tsx
+++ b/src/app/admin/(with-sidebar)/application-form/page.tsx
@@ -1,0 +1,3 @@
+export default function AdminApplicationFormPage() {
+  return <div>어드민 지원서 수정</div>;
+}

--- a/src/app/admin/(with-sidebar)/applications/page.tsx
+++ b/src/app/admin/(with-sidebar)/applications/page.tsx
@@ -1,0 +1,3 @@
+export default function AdminApplicationPage() {
+  return <div>지원서 열람</div>;
+}

--- a/src/app/admin/(with-sidebar)/layout.tsx
+++ b/src/app/admin/(with-sidebar)/layout.tsx
@@ -1,0 +1,14 @@
+import {AdminSideBar} from '@/app/admin/_components/AdminSideBar';
+
+export default function AdminWithSideBarLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <section className='flex min-h-screen w-full flex-row gap-23.5 bg-neutral-50 px-60 py-16.75'>
+      <AdminSideBar />
+      <main className='flex-1'>{children}</main>
+    </section>
+  );
+}

--- a/src/app/admin/(with-sidebar)/recruitment/page.tsx
+++ b/src/app/admin/(with-sidebar)/recruitment/page.tsx
@@ -1,0 +1,3 @@
+export default function AdminRecruitmentPage() {
+  return <div>모집 활성화</div>;
+}

--- a/src/app/admin/(with-sidebar)/results/page.tsx
+++ b/src/app/admin/(with-sidebar)/results/page.tsx
@@ -1,0 +1,3 @@
+export default function AdminResultsPage() {
+  return <div>합격자 관리</div>;
+}

--- a/src/app/admin/_components/AdminSideBar.tsx
+++ b/src/app/admin/_components/AdminSideBar.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import {ADMIN_NAV_ITEMS} from '@/constants/admin/admin-sidebar';
+import clsx from 'clsx';
+import Link from 'next/link';
+import {usePathname} from 'next/navigation';
+
+export const AdminSideBar = () => {
+  const pathname = usePathname();
+
+  return (
+    <nav className='flex w-62.5 flex-col gap-7.5'>
+      <h2 className='text-h4 text-neutral-400'>관리자 페이지</h2>
+      <ul className='flex w-full flex-col gap-2.5'>
+        {ADMIN_NAV_ITEMS.map(({label, href}) => {
+          const isActive = pathname === href || pathname.startsWith(`${href}/`);
+
+          return (
+            <li key={href}>
+              <Link
+                href={href}
+                aria-current={isActive ? 'page' : undefined}
+                className={clsx(
+                  'block w-full rounded-[10px] px-2 py-2.5 text-h5 transition-colors',
+                  isActive && 'bg-neutral-800 text-neutral-100'
+                )}>
+                {label}
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+};

--- a/src/constants/admin/admin-sidebar.ts
+++ b/src/constants/admin/admin-sidebar.ts
@@ -1,0 +1,8 @@
+import {ROUTES} from '@/constants/routes';
+
+export const ADMIN_NAV_ITEMS = [
+  {label: '지원서 열람', href: ROUTES.ADMIN_APPLICATION},
+  {label: '지원서 수정', href: ROUTES.ADMIN_APPLICATION_FORM},
+  {label: '모집 활성화', href: ROUTES.ADMIN_RECRUITMENT},
+  {label: '합격자 관리', href: ROUTES.ADMIN_RESULTS},
+];

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -1,0 +1,7 @@
+export const ROUTES = {
+  ADMIN: '/admin',
+  ADMIN_APPLICATION: '/admin/applications',
+  ADMIN_APPLICATION_FORM: '/admin/application-form',
+  ADMIN_RECRUITMENT: '/admin/recruitment',
+  ADMIN_RESULTS: '/admin/results',
+};


### PR DESCRIPTION
## ISSUE 🔗

<!-- ex) close #이슈번호 -->
#5 

<br><br>

## What is this PR? 🔍

<!-- 작업 내용을 설명해 주세요 -->

## 관리자 페이지 사이드 탭 컴포넌트 및 레이아웃 구성

사이드 탭바를 포함하는 페이지는 (with-sidebar) 하위에 구현해 뒀습니다.
초기 레이아웃 구성을 위해 어드민 도메인 경로를 구성했습니다.

* 지원서 열람 - `/admin/applications`
* 지원서 수정 - `/admin/application-form`
* 모집 활성화 - `/admin/recruitment`
* 합격자 관리 - `/admin/results` 

도메인 경로명들은 논의 후 더 좋은 방향으로 확정지어도 될 것 같습니다.

어드민 기능 중 지원자 지원서 열람 기능과 같은 경우는 사이드바가 포함되지 않는 페이지이므로, 해당 페이지는 어드민 하위 (no-sidebar) 폴더 내부에서 구현될 예정입니다.

## 라우팅 경로 상수화 파일 추가
`constants/route.ts`에서 서비스의 모든 도메인 경로를 포함하는 상수 파일이 추가되었습니다. 추후 기능 확장하시면서 라우트 파일에 도메인 경로 추가해 주시면 될 것 같습니다


<br><br>

## Screenshot 📷

<!-- 구현된 기능/디자인 gif -->
![Animation](https://github.com/user-attachments/assets/25d1c8a7-6aeb-472c-a7ed-4fd45ebd3ff9)

<br><br>

## Test Checklist ✔

<!-- 어떤 내용을 테스트했는지/해야 하는지 -->

- [ ] 도메인 경로 확인
- [ ] 라우팅 확인 
- [ ] 사이드바 UI 확인!
