### PR TITLE
[FEAT]: 지원서 지원 일정 UI 및 배너 추가

### DIFF
--- a/src/app/admin/(with-sidebar)/application-form/_components/recruitment/AdminRecruitmentInformation.tsx
+++ b/src/app/admin/(with-sidebar)/application-form/_components/recruitment/AdminRecruitmentInformation.tsx
@@ -12,11 +12,13 @@ type RecruitmentValue = {
   end?: string;
 };
 
-type Props = {
+interface AdminRecruitmentInformationProps {
   variant?: 'bordered' | 'plain';
-};
+}
 
-export const AdminRecruitmentInformation = ({variant = 'bordered'}: Props) => {
+export const AdminRecruitmentInformation = ({
+  variant = 'bordered',
+}: AdminRecruitmentInformationProps) => {
   const isEditing = useAdminApplicationFormStore(
     (s) => s.isEditingRecruitmentInfo
   );

--- a/src/app/admin/(with-sidebar)/application-form/_components/recruitment/AdminRecruitmentInformation.tsx
+++ b/src/app/admin/(with-sidebar)/application-form/_components/recruitment/AdminRecruitmentInformation.tsx
@@ -5,13 +5,18 @@ import {RecruitmentInfoViewRow} from '@/app/admin/(with-sidebar)/application-for
 import {scheduleSections} from '@/constants/admin/admin-application-form';
 import {mockRecruitmentInfo} from '@/mocks/mock-application-form';
 import {useAdminApplicationFormStore} from '@/store/useAdminApplicationFormStore';
+import {clsx} from 'clsx';
 
 type RecruitmentValue = {
   start?: string;
   end?: string;
 };
 
-export const AdminRecruitmentInformation = () => {
+type Props = {
+  variant?: 'bordered' | 'plain';
+};
+
+export const AdminRecruitmentInformation = ({variant = 'bordered'}: Props) => {
   const isEditing = useAdminApplicationFormStore(
     (s) => s.isEditingRecruitmentInfo
   );
@@ -36,7 +41,11 @@ export const AdminRecruitmentInformation = () => {
   };
 
   return (
-    <div className='flex flex-col gap-3 rounded-[10px] border border-neutral-300 px-4 py-5.25'>
+    <div
+      className={clsx(
+        'flex flex-col gap-3 rounded-[10px]',
+        variant === 'bordered' && 'border border-neutral-300 px-4 py-5.25'
+      )}>
       {scheduleSections.map(({key, label, type}) =>
         isEditing ? (
           <RecruitmentInfoEditRow

--- a/src/app/apply/_components/ApplyFormContainer.tsx
+++ b/src/app/apply/_components/ApplyFormContainer.tsx
@@ -5,9 +5,12 @@ import {FormProvider} from 'react-hook-form';
 import {StepIndicator} from '@/components/navigation/StepIndicator';
 import {BasicInfo} from '@/app/apply/_components/BasicInfo';
 import {PartQuestion} from '@/app/apply/_components/PartQuestion';
-import {AdditionalInfo} from '@/app/apply/_components/AdditionalInfo';
+import {EtcInfo} from '@/app/apply/_components/EtcInfo';
 import {useApplyFormController} from '@/app/apply/_hooks/useApplyFormController';
 import {useScrollToTop} from '@/hooks/useScrollToTop';
+import {AdminRecruitmentInformation} from '@/app/admin/(with-sidebar)/application-form/_components/recruitment/AdminRecruitmentInformation';
+import {useRecruitmentStore} from '@/store/useRecruitmentStore';
+import HeroMainBanner from '@/components/banner/HeroMainBanner';
 
 const STEP_TITLES = {
   1: '기본 인적사항',
@@ -19,15 +22,26 @@ export const ApplyFormContainer = () => {
   const {step, methods, handleNext, handlePrev, handleSave, handleFinalSubmit} =
     useApplyFormController();
 
+  const generation = useRecruitmentStore((state) => state.generation);
+
   const scrollToTop = useScrollToTop();
 
   useEffect(() => {
     scrollToTop();
   }, [step, scrollToTop]);
   return (
-    <div className='flex w-full justify-center'>
-      <div className='flex w-full max-w-[1196px] flex-col gap-[125px] py-20'>
-        <h1 className='text-h2 font-bold text-neutral-800'>
+    <div className='flex flex-col items-center'>
+      {step === 1 && <HeroMainBanner />}
+
+      <div className='flex w-full max-w-[1196px] flex-col justify-center gap-[125px] py-20'>
+        <div className='flex flex-col gap-15'>
+          <h1 className='text-h1 text-neutral-800'>
+            🥔 코테이토 {generation}기 지원서 🥔
+          </h1>
+          <AdminRecruitmentInformation variant='plain' />
+        </div>
+
+        <h1 className='text-h2 text-neutral-800'>
           {STEP_TITLES[step as keyof typeof STEP_TITLES]}
         </h1>
 
@@ -49,7 +63,7 @@ export const ApplyFormContainer = () => {
                 />
               )}
               {step === 3 && (
-                <AdditionalInfo onPrev={handlePrev} onSave={handleSave} />
+                <EtcInfo onPrev={handlePrev} onSave={handleSave} />
               )}
             </form>
           </FormProvider>

--- a/src/app/apply/_components/ApplyFormContainer.tsx
+++ b/src/app/apply/_components/ApplyFormContainer.tsx
@@ -36,14 +36,16 @@ export const ApplyFormContainer = () => {
       <div className='flex w-full max-w-[1196px] flex-col justify-center gap-[125px] py-20'>
         <div className='flex flex-col gap-15'>
           <h1 className='text-h1 text-neutral-800'>
-            🥔 코테이토 {generation}기 지원서 🥔
+            <span aria-hidden='true'>🥔</span>
+            &nbsp;코테이토 {generation}기 지원서&nbsp;
+            <span aria-hidden='true'>🥔</span>
           </h1>
           <AdminRecruitmentInformation variant='plain' />
         </div>
 
-        <h1 className='text-h2 text-neutral-800'>
+        <h2 className='text-h2 text-neutral-800'>
           {STEP_TITLES[step as keyof typeof STEP_TITLES]}
-        </h1>
+        </h2>
 
         <div className='flex w-full flex-col gap-[81px]'>
           <div className='flex justify-center'>

--- a/src/app/apply/_components/EtcInfo.tsx
+++ b/src/app/apply/_components/EtcInfo.tsx
@@ -10,7 +10,7 @@ import {FormInput} from '@/components/form/FormInput';
 import {ADDITIONAL_FIELDS} from '@/constants/form/formConfig';
 import {AdditionalFieldConfig} from '@/schemas/apply-type';
 
-export const AdditionalInfo = ({
+export const EtcInfo = ({
   onPrev,
   onSave,
 }: {

--- a/src/app/apply/_components/EtcInfo.tsx
+++ b/src/app/apply/_components/EtcInfo.tsx
@@ -8,7 +8,7 @@ import {FullButton} from '@/components/button/FullButton';
 import {FormRadio} from '@/components/form/FormRadio';
 import {FormInput} from '@/components/form/FormInput';
 import {ADDITIONAL_FIELDS} from '@/constants/form/formConfig';
-import {AdditionalFieldConfig} from '@/schemas/apply-type';
+import {EtcFieldConfig} from '@/schemas/apply-type';
 
 export const EtcInfo = ({
   onPrev,
@@ -24,7 +24,7 @@ export const EtcInfo = ({
     formState: {errors},
   } = useFormContext();
 
-  const renderField = (field: AdditionalFieldConfig) => {
+  const renderField = (field: EtcFieldConfig) => {
     const {
       type,
       name,

--- a/src/schemas/apply-type.ts
+++ b/src/schemas/apply-type.ts
@@ -26,8 +26,8 @@ export type BasicInfoFormItem =
   | BasicInfoFieldConfig
   | {row: readonly BasicInfoFieldConfig[]; name?: never; type?: never};
 
-// AdditionalInfo
-export interface AdditionalFieldConfig {
+// EtcInfo
+export interface EtcFieldConfig {
   name?: string;
   label?: string;
   type: string;
@@ -41,5 +41,5 @@ export interface AdditionalFieldConfig {
 }
 
 export type AdditionalFormItem =
-  | AdditionalFieldConfig
-  | {type: 'row'; row: AdditionalFieldConfig[]; name?: never};
+  | EtcFieldConfig
+  | {type: 'row'; row: EtcFieldConfig[]; name?: never};


### PR DESCRIPTION
## ISSUE 🔗

<!-- ex) close #이슈번호 -->
close #35 

<br><br>

## What is this PR? 🔍

<!-- 작업 내용을 설명해 주세요 -->
##  UI 개선 및 채용 정보 표시

* **`AdminRecruitmentInformation` 컴포넌트 고도화**: `variant` prop이 추가되어 스타일 제어가 가능해졌습니다. 이제 상황에 따라 테두리가 있는 형태(bordered)나 평면적인 형태(plain)로 재사용할 수 있으며, `clsx` 라이브러리를 사용하여 조건부 클래스명을 효율적으로 관리합니다.
* **지원서 상단 정보 노출**: `ApplyFormContainer`의 첫 번째 단계(step 1) 상단에 `AdminRecruitmentInformation`이 배치되었습니다. 지원자에게 일관된 스타일(테두리 없는 plain 스타일)로 채용 상세 정보를 제공합니다.
* **동적 헤더 적용**: 메인 지원서 헤더가 `useRecruitmentStore`에서 가져온 `generation` 값을 사용하여 현재 기수를 동적으로 표시합니다.

## 컴포넌트 이름 변경 및 리팩토링

* **명칭 변경 (`AdditionalInfo` → `EtcInfo`)**: 컴포넌트의 목적을 더욱 명확하게 하고 swagger 도메인과의 일관성을 유지하기 위해 `AdditionalInfo`를 `EtcInfo`로 변경했습니다. 
* 다만 폴더명은 `apply` 그대로 두었습니다. > 사용자 url에 `applications`보다는 `apply`가 적합하다고 생각했기 때문입니다. 이것도 일관성 유지를 위해 바꾸는 게 좋다고 하시면 바꾸겠습니다.

## 레이아웃 및 구조 최적화

* **전반적인 레이아웃 개선**: 지원서 양식의 구조를 개선했습니다. 특히 첫 번째 단계 최상단에 `HeroMainBanner`를 추가하고, 폼 콘텐츠의 정렬을 다듬어 전반적인 가독성을 높였습니다.


<br><br>

## Screenshot 📷

<!-- 구현된 기능/디자인 gif -->
![화면 기록 2026-01-09 오전 9 43 40](https://github.com/user-attachments/assets/86e19280-e51a-4242-ae1c-eaa9b142a575)

<br><br>

## Test Checklist ✔

<!-- 어떤 내용을 테스트했는지/해야 하는지 -->

- [ ] UI 확인

