### PR TITLE
[FEAT]: 메일 관리 API 연결

### DIFF
--- a/src/app/admin/(with-sidebar)/recruitment/_components/active-recruitment/ActiveRecruitmentForm.tsx
+++ b/src/app/admin/(with-sidebar)/recruitment/_components/active-recruitment/ActiveRecruitmentForm.tsx
@@ -81,6 +81,7 @@ export const ActiveRecruitmentForm = () => {
             setStartDate={setStartDate}
             endDate={endDate}
             setEndDate={setEndDate}
+            disabled={isRecruiting}
           />
           <div className='flex shrink-0 cursor-pointer items-center gap-5 whitespace-nowrap select-none'>
             <span className='text-body-L text-neutral-600'>추가모집 여부</span>

--- a/src/app/admin/(with-sidebar)/recruitment/_components/active-recruitment/ActiveRecruitmentForm.tsx
+++ b/src/app/admin/(with-sidebar)/recruitment/_components/active-recruitment/ActiveRecruitmentForm.tsx
@@ -71,7 +71,11 @@ export const ActiveRecruitmentForm = () => {
         className='flex h-25 items-end justify-between rounded-[10px] bg-neutral-100 pt-3 pr-5 pb-3 pl-3.5'>
         <fieldset className='flex h-19 items-end justify-end gap-11.75 pb-1 text-body-m font-semibold'>
           <legend className='sr-only'>모집 설정</legend>
-          <GenerationField value={generation} onChange={setGeneration} />
+          <GenerationField
+            value={generation}
+            onChange={setGeneration}
+            disabled={isRecruiting}
+          />
           <PeriodField
             startDate={startDate}
             setStartDate={setStartDate}

--- a/src/app/admin/(with-sidebar)/recruitment/_components/active-recruitment/GenerationField.tsx
+++ b/src/app/admin/(with-sidebar)/recruitment/_components/active-recruitment/GenerationField.tsx
@@ -1,15 +1,21 @@
 interface GenerationFieldProps {
   value: string;
   onChange: (val: string) => void;
+  disabled?: boolean;
 }
 
-export const GenerationField = ({value, onChange}: GenerationFieldProps) => {
+export const GenerationField = ({
+  value,
+  onChange,
+  disabled,
+}: GenerationFieldProps) => {
   return (
     <div className='flex w-24.5 flex-col gap-2'>
       <label>기수 정보</label>
       <div className='flex items-center gap-2'>
         <input
           value={value}
+          disabled={disabled}
           onChange={(e) => onChange(e.target.value)}
           className='w-19 rounded-[10px] bg-neutral-50 pt-1.5 pb-2.5 text-center text-body-m'
           aria-label='기수 입력'

--- a/src/app/admin/(with-sidebar)/recruitment/_components/active-recruitment/PeriodField.tsx
+++ b/src/app/admin/(with-sidebar)/recruitment/_components/active-recruitment/PeriodField.tsx
@@ -11,6 +11,7 @@ interface PeriodFieldProps {
   setStartDate: (date: Date | null) => void;
   endDate: Date | null;
   setEndDate: (date: Date | null) => void;
+  disabled?: boolean;
 }
 
 export const PeriodField = ({
@@ -18,6 +19,7 @@ export const PeriodField = ({
   setStartDate,
   endDate,
   setEndDate,
+  disabled,
 }: PeriodFieldProps) => {
   return (
     <fieldset className='flex w-full flex-col gap-4'>
@@ -26,9 +28,10 @@ export const PeriodField = ({
         <div className='relative'>
           <DatePicker
             selected={startDate}
+            disabled={disabled}
             onChange={(date: Date | null) => setStartDate(date)}
             dateFormat='yyyy-MM-dd'
-            customInput={<CustomInput />}
+            customInput={<CustomInput disabled={disabled} />}
             popperPlacement='bottom-start'
             formatWeekDay={(nameOfDay) => nameOfDay.toLowerCase().slice(0, 3)}
             renderCustomHeader={(props) => <CustomHeader {...props} />}
@@ -38,10 +41,11 @@ export const PeriodField = ({
         <div className='relative'>
           <DatePicker
             selected={endDate}
+            disabled={disabled}
             onChange={(date: Date | null) => setEndDate(date)}
             minDate={startDate ?? undefined}
             dateFormat='yyyy-MM-dd'
-            customInput={<CustomInput />}
+            customInput={<CustomInput disabled={disabled} />}
             popperPlacement='bottom-start'
             formatWeekDay={(nameOfDay) => nameOfDay.toLowerCase().slice(0, 3)}
             renderCustomHeader={(props) => <CustomHeader {...props} />}

--- a/src/app/admin/(with-sidebar)/recruitment/_components/calendar/CustomInput.tsx
+++ b/src/app/admin/(with-sidebar)/recruitment/_components/calendar/CustomInput.tsx
@@ -1,19 +1,28 @@
 import React, {forwardRef} from 'react';
 import CalendarIcon from '@/assets/calendar/calendar.svg';
+import clsx from 'clsx';
 
 interface CustomInputProps {
   value?: string;
   onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  disabled?: boolean;
 }
 
 export const CustomInput = forwardRef<HTMLButtonElement, CustomInputProps>(
-  ({value, onClick}, ref) => {
+  ({value, onClick, disabled}, ref) => {
     return (
       <button
         type='button'
         ref={ref}
         onClick={onClick}
-        className='flex h-9 w-38.5 items-center justify-between gap-2.5 rounded-[12px] bg-neutral-50 px-3.5 py-1.5 text-body-m'>
+        disabled={disabled}
+        className={clsx(
+          'flex h-9 w-38.5 items-center justify-between gap-2.5 rounded-[12px] bg-neutral-50 px-3.5 py-1.5 text-body-m',
+          {
+            'cursor-pointer': !disabled,
+            'cursor-default': disabled,
+          }
+        )}>
         <span>{value}</span>
         <CalendarIcon />
       </button>

--- a/src/app/admin/(with-sidebar)/recruitment/_components/manage-mail/ManageMail.tsx
+++ b/src/app/admin/(with-sidebar)/recruitment/_components/manage-mail/ManageMail.tsx
@@ -10,7 +10,7 @@ import {MailConfirmModal} from '@/components/modal/MailConfirmModal';
 import {Spinner} from '@/components/ui/Spinner';
 
 interface ManageMailProps {
-  mailType: string;
+  mailType?: string;
   alwaysAble?: boolean;
 }
 

--- a/src/app/admin/(with-sidebar)/recruitment/_components/manage-mail/ManageMail.tsx
+++ b/src/app/admin/(with-sidebar)/recruitment/_components/manage-mail/ManageMail.tsx
@@ -38,7 +38,7 @@ export const ManageMail = ({
 
   if (isLoading) {
     return (
-      <div className='w-full items-center justify-center'>
+      <div className='flex w-full items-center justify-center'>
         <Spinner size='lg' />
       </div>
     );

--- a/src/app/admin/(with-sidebar)/results/_components/mail-manage/MailSelect.tsx
+++ b/src/app/admin/(with-sidebar)/results/_components/mail-manage/MailSelect.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import {mailTabs} from '@/constants/admin/admin-result';
 import clsx from 'clsx';
 import {FullButton} from '@/components/button/FullButton';
+import {mailTabs} from '@/schemas/admin/admin-mail-type';
 
 interface MailSelectProps {
   activeTab: string;

--- a/src/assets/check/check.svg
+++ b/src/assets/check/check.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="current" height="current" viewBox="0 0 10 8" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 8" fill="none">
   <path d="M3.53553 4.94975L1.41421 2.82843L0 4.24264L3.53553 7.77817L9.8995 1.41421L8.48528 0L3.53553 4.94975Z" fill="currentColor"/>
 </svg>

--- a/src/constants/admin/admin-result.ts
+++ b/src/constants/admin/admin-result.ts
@@ -1,15 +1,3 @@
-import {
-  MAIL_ALARM_NUM,
-  MAIL_FAIL_NUM,
-  MAIL_PASS_NUM,
-  MAIL_WAITING_NUM,
-  MOCK_MAIL_CONTENT_ALARM,
-  MOCK_MAIL_CONTENT_FAIL,
-  MOCK_MAIL_CONTENT_PASS,
-  MOCK_MAIL_CONTENT_WAITING,
-} from '@/mocks/mock-mail';
-import {MailType} from '@/schemas/admin/admin-result-type';
-
 export const RESULT_PARTS = [
   {label: '전체', value: 'total'},
   {label: '기획', value: 'plan'},
@@ -17,19 +5,3 @@ export const RESULT_PARTS = [
   {label: '프론트엔드', value: 'frontend'},
   {label: '백엔드', value: 'backend'},
 ] as const;
-
-export const MAIL_DATA_MAP: Record<string, string> = {
-  '지원 알림 메일': MOCK_MAIL_CONTENT_ALARM,
-  '합격자 메일': MOCK_MAIL_CONTENT_PASS,
-  '불합격자 메일': MOCK_MAIL_CONTENT_FAIL,
-  '예비 합격자 메일': MOCK_MAIL_CONTENT_WAITING,
-};
-
-export const MAIL_NUM_MAP: Record<MailType, number> = {
-  '지원 알림 메일': MAIL_ALARM_NUM,
-  '합격자 메일': MAIL_PASS_NUM,
-  '불합격자 메일': MAIL_FAIL_NUM,
-  '예비 합격자 메일': MAIL_WAITING_NUM,
-};
-
-export const mailTabs = ['합격자 메일', '불합격자 메일', '예비 합격자 메일'];

--- a/src/constants/query-keys.ts
+++ b/src/constants/query-keys.ts
@@ -2,4 +2,5 @@ export const QUERY_KEYS = {
   ADMIN_APPLICATION: 'admin-applications',
   ADMIN_RECRUITMENT_INFORMATIONS: 'admin-recruitment-informations',
   RECRUITMENT_STATUS: 'recruitment-status',
+  MAIL_STATUS: 'mail-status',
 } as const;

--- a/src/hooks/mutations/useAdminMailMutation.ts
+++ b/src/hooks/mutations/useAdminMailMutation.ts
@@ -16,7 +16,7 @@ export const useAdminMailMutation = (
     onSuccess: () => {
       queryClient.invalidateQueries({queryKey});
     },
-    onError: (error: ErrorResponse) => {
+    onError: (error: ErrorResponse | Error) => {
       alert(error.message || '저장 중 오류가 발생했습니다.');
     },
   });
@@ -26,8 +26,8 @@ export const useAdminMailMutation = (
     onSuccess: () => {
       queryClient.invalidateQueries({queryKey});
     },
-    onError: (error: ErrorResponse) => {
-      alert(error.message || '전송 중 오류가 발생했습니다.');
+    onError: (error: ErrorResponse | Error) => {
+      alert(error.message || '저장 중 오류가 발생했습니다.');
     },
   });
 

--- a/src/hooks/mutations/useAdminMailMutation.ts
+++ b/src/hooks/mutations/useAdminMailMutation.ts
@@ -1,0 +1,40 @@
+import {useMutation, useQueryClient} from '@tanstack/react-query';
+import {QUERY_KEYS} from '@/constants/query-keys';
+import {saveMailContent, sendMail} from '@/services/api/admin/admin.mail.api';
+import {ErrorResponse} from '@/schemas/common/common-schema';
+
+export const useAdminMailMutation = (
+  generationId: number,
+  mailType: string
+) => {
+  const queryClient = useQueryClient();
+  const queryKey = [QUERY_KEYS.MAIL_STATUS, generationId, mailType];
+
+  const saveMutation = useMutation({
+    mutationFn: (content: string) =>
+      saveMailContent(generationId, mailType, content),
+    onSuccess: () => {
+      queryClient.invalidateQueries({queryKey});
+    },
+    onError: (error: ErrorResponse) => {
+      alert(error.message || '저장 중 오류가 발생했습니다.');
+    },
+  });
+
+  const sendMutation = useMutation({
+    mutationFn: () => sendMail(generationId, mailType),
+    onSuccess: () => {
+      queryClient.invalidateQueries({queryKey});
+    },
+    onError: (error: ErrorResponse) => {
+      alert(error.message || '전송 중 오류가 발생했습니다.');
+    },
+  });
+
+  return {
+    save: saveMutation.mutate,
+    send: sendMutation.mutate,
+    isSaving: saveMutation.isPending,
+    isSending: sendMutation.isPending,
+  };
+};

--- a/src/hooks/queries/useAdminMailQuery.ts
+++ b/src/hooks/queries/useAdminMailQuery.ts
@@ -1,0 +1,10 @@
+import {useQuery} from '@tanstack/react-query';
+import {QUERY_KEYS} from '@/constants/query-keys';
+import {getMailData} from '@/services/api/admin/admin.mail.api';
+
+export const useAdminMailQuery = (generationId: number, mailType: string) => {
+  return useQuery({
+    queryKey: [QUERY_KEYS.MAIL_STATUS, generationId, mailType],
+    queryFn: () => getMailData(generationId, mailType),
+  });
+};

--- a/src/schemas/admin/admin-mail-schema.ts
+++ b/src/schemas/admin/admin-mail-schema.ts
@@ -1,0 +1,38 @@
+import {z} from 'zod';
+import {createSuccessResponseSchema} from '@/schemas/common/common-schema';
+
+const BaseMailDataSchema = z.object({
+  templateId: z.number().nullable(),
+  content: z.string(),
+  isSent: z.boolean(),
+  sentAt: z.string().nullable(),
+  generationId: z.number(),
+});
+
+// 지원 알림 메일 데이터
+export const NotificationMailDataSchema = BaseMailDataSchema.extend({
+  subscriberCount: z.number(),
+});
+
+// 결과 통보 메일 데이터 (합격/불합격/예비)
+export const ResultMailDataSchema = BaseMailDataSchema.extend({
+  templateType: z.string(),
+  templateTypeDescription: z.string(),
+  recipientCount: z.number(),
+});
+
+// 메일 전송 응답 데이터
+export const MailSendResultSchema = createSuccessResponseSchema(
+  z.object({
+    successCount: z.number(),
+    failCount: z.number(),
+    sentAt: z.string(),
+    generationId: z.number(),
+  })
+);
+
+export const NotificationMailResponseSchema = createSuccessResponseSchema(
+  NotificationMailDataSchema
+);
+export const ResultMailResponseSchema =
+  createSuccessResponseSchema(ResultMailDataSchema);

--- a/src/schemas/admin/admin-mail-type.ts
+++ b/src/schemas/admin/admin-mail-type.ts
@@ -1,0 +1,7 @@
+export const MAIL_TYPE_MAP = {
+  '합격자 메일': 'PASS',
+  '불합격자 메일': 'FAIL',
+  '예비 합격자 메일': 'PRELIMINARY',
+} as const;
+
+export const mailTabs = ['합격자 메일', '불합격자 메일', '예비 합격자 메일'];

--- a/src/schemas/admin/admin-mail-type.ts
+++ b/src/schemas/admin/admin-mail-type.ts
@@ -1,7 +1,7 @@
 export const MAIL_TYPE_MAP = {
   '합격자 메일': 'PASS',
   '불합격자 메일': 'FAIL',
-  '예비 합격자 메일': 'PRELIMINARY',
+  '예비합격자 메일': 'PRELIMINARY',
 } as const;
 
-export const mailTabs = ['합격자 메일', '불합격자 메일', '예비 합격자 메일'];
+export const mailTabs = ['합격자 메일', '불합격자 메일', '예비합격자 메일'];

--- a/src/schemas/admin/admin-result-type.ts
+++ b/src/schemas/admin/admin-result-type.ts
@@ -1,6 +1,4 @@
-import {MAIL_DATA_MAP, RESULT_PARTS} from '@/constants/admin/admin-result';
-
-export type MailType = keyof typeof MAIL_DATA_MAP;
+import {RESULT_PARTS} from '@/constants/admin/admin-result';
 
 export type ResultPartValue = (typeof RESULT_PARTS)[number]['value'];
 

--- a/src/services/api/admin/admin.mail.api.ts
+++ b/src/services/api/admin/admin.mail.api.ts
@@ -1,0 +1,78 @@
+import {privateAxios} from '@/services/config/axios';
+import {ENDPOINT} from '@/services/constant/endpoint';
+import {handleApiError} from '@/services/utils/apiHelper';
+import {
+  NotificationMailResponseSchema,
+  ResultMailResponseSchema,
+  MailSendResultSchema,
+} from '@/schemas/admin/admin-mail-schema';
+import {MAIL_TYPE_MAP} from '@/schemas/admin/admin-mail-type';
+
+export const getMailData = async (generationId: number, mailType: string) => {
+  try {
+    const isNotification = mailType === '지원 알림 메일';
+    const url = isNotification
+      ? ENDPOINT.ADMIN.RECRUITMENT_NOTIFICATION
+      : ENDPOINT.ADMIN.RECRUITMENT_RESULT;
+
+    const params = {
+      generationId,
+      ...(!isNotification && {
+        templateType: MAIL_TYPE_MAP[mailType as keyof typeof MAIL_TYPE_MAP],
+      }),
+    };
+
+    const response = await privateAxios.get(url, {params});
+    return isNotification
+      ? NotificationMailResponseSchema.parse(response.data).data
+      : ResultMailResponseSchema.parse(response.data).data;
+  } catch (error) {
+    return handleApiError(error);
+  }
+};
+
+export const saveMailContent = async (
+  generationId: number,
+  mailType: string,
+  content: string
+) => {
+  try {
+    const isNotification = mailType === '지원 알림 메일';
+    const url = isNotification
+      ? ENDPOINT.ADMIN.RECRUITMENT_NOTIFICATION
+      : ENDPOINT.ADMIN.RECRUITMENT_RESULT;
+    const body = {
+      generationId,
+      content,
+      ...(!isNotification && {
+        templateType: MAIL_TYPE_MAP[mailType as keyof typeof MAIL_TYPE_MAP],
+      }),
+    };
+
+    const response = await privateAxios.post(url, body);
+    return response.data;
+  } catch (error) {
+    return handleApiError(error);
+  }
+};
+
+export const sendMail = async (generationId: number, mailType: string) => {
+  try {
+    const isNotification = mailType === '지원 알림 메일';
+    const url = isNotification
+      ? ENDPOINT.ADMIN.RECRUITMENT_NOTIFICATION_SEND
+      : ENDPOINT.ADMIN.RECRUITMENT_RESULT_SEND;
+
+    const body = {
+      generationId,
+      ...(!isNotification && {
+        templateType: MAIL_TYPE_MAP[mailType as keyof typeof MAIL_TYPE_MAP],
+      }),
+    };
+
+    const response = await privateAxios.post(url, body);
+    return MailSendResultSchema.parse(response.data).data;
+  } catch (error) {
+    return handleApiError(error);
+  }
+};

--- a/src/services/api/admin/admin.mail.api.ts
+++ b/src/services/api/admin/admin.mail.api.ts
@@ -8,6 +8,14 @@ import {
 } from '@/schemas/admin/admin-mail-schema';
 import {MAIL_TYPE_MAP} from '@/schemas/admin/admin-mail-type';
 
+const getTemplateType = (mailType: string) => {
+  const templateType = MAIL_TYPE_MAP[mailType as keyof typeof MAIL_TYPE_MAP];
+  if (!templateType) {
+    throw new Error(`Invalid mail type: ${mailType}`);
+  }
+  return templateType;
+};
+
 export const getMailData = async (generationId: number, mailType: string) => {
   try {
     const isNotification = mailType === '지원 알림 메일';
@@ -18,7 +26,7 @@ export const getMailData = async (generationId: number, mailType: string) => {
     const params = {
       generationId,
       ...(!isNotification && {
-        templateType: MAIL_TYPE_MAP[mailType as keyof typeof MAIL_TYPE_MAP],
+        templateType: getTemplateType(mailType),
       }),
     };
 

--- a/src/services/constant/endpoint.ts
+++ b/src/services/constant/endpoint.ts
@@ -22,5 +22,10 @@ export const ENDPOINT = {
     APPLICATIONS: '/api/admin/applications',
     RECRUITMENT_ACTIVATION: '/api/admin/recruitment-activation',
     RECRUITMENT_DEACTIVATION: '/api/admin/recruitment-deactivation',
+    RECRUITMENT_NOTIFICATION: '/api/admin/recruitment-notification-emails',
+    RECRUITMENT_NOTIFICATION_SEND:
+      '/api/admin/recruitment-notification-emails/send',
+    RECRUITMENT_RESULT: '/api/admin/recruitment-mails',
+    RECRUITMENT_RESULT_SEND: '/api/admin/recruitment-mails/send',
   },
 };


### PR DESCRIPTION
## ISSUE 🔗

<!-- ex) close #이슈번호 --> 
close #21 

<br><br>

## What is this PR? 🔍

<!-- 작업 내용을 설명해 주세요 -->
## 메일 관리 API 연동
어드민 페이지의 메일 관리(조회, 저장, 전송) 관련 API를 연결했습니다. 
현재 모집 알림, 합격자, 불합격자, 예비 합격자 메일 모두 연결되어있습니다.

- `useAdminMailMutation`, `useAdminMailQuery` 추가
- `admin-mail-schema`, `admin-mail-type` 추가
- 기존 목데이터 기반으로 구현하였던 `useManageMail`, `ManageMail`을 실제 데이터 로직에 맞춰 수정했습니다. 
- 모집 활성화 탭에서의 메일 관리는 모집 알림 메일 api를 사용해야하고, 합격자관리 탭에서의 메일 관리는 합격/불합격/예비 메일 api를 사용해야하기 때문에, 이를 `admin.mail.api.ts` 파일에서 mailType이 '지원 알림 메일'일 경우에만 true인 `isNotification`라는 상수를 이용하여 _url, body_ 를 제어했습니다.

### 참고 1
현재 모집 알림 신청 api가 연결이 아직 안되어있는 관계로 메일 전송에 대한 테스트는 제대로 해보지 못하는 상태입니다. 오늘 회의에서 백엔드 분들께 제 메일 알려드리고 부탁드릴듯.. 일단 현재는 db에도 아마 메일 대기자가 없을 거라 메일을 보내도 에러가 뜨긴하는데 api 연결 자체는 제대로 되어있습니다. 

### 참고 2
위와 이어지는 부분인데, 메일 알려드리고 메일 전송 테스트해보면서 메일 전송 로직을 다시 점검할 예정입니다. 예를 들어, 메일을 한 번 보내면 다시 보낼 수 없음, 모집 알림 메일을 한 번 보내게 되면 대기자 수는 0명으로 바뀜 등등 메일 관련 로직이 너무 복잡해서 이 부분은 추후 다시 점검할 예정입니다.............................( ㅠㅠ)

### 참고 3
현재 메일 수정이나 전송을 하게되면 완료알림이 alert로 뜨는데 일단 테스트를 위해 alert로 둔거라 추후 관련 UI가 나오거나, 없어도 된다고 판단하면 alert는 제거할 예정입니다.

<br><br>

## 모집 활성화 상태 시 수정 관련 리팩토링
기존에는 모집 활성화 상태일 때에도 (isActive===true) 기수, 지원기간 등을 수정할 수 있었는데, UX적으로 부적절하다고 판단하여 isActive 상태(코드에서는 isRecruiting)일 때는 기수 input, 지원기간 datepicker 모두 disabled 되도록 수정하였습니다. 모집을 종료하면 다시 수정이 가능합니다.

<br><br>

## Screenshot 📷

<!-- 구현된 기능/디자인 gif -->
![3](https://github.com/user-attachments/assets/073defc4-d133-4ea3-8cc0-dbfa05bfc87d)

<img width="1918" height="863" alt="image" src="https://github.com/user-attachments/assets/9fb4849b-48c0-4b0a-8621-df1f016fc435" />
위 이미지에서는 모집 중이지만 대기자 수가 0명이라 메일 전송 버튼이 disabled입니다.

<br><br>

## Test Checklist ✔

<!-- 어떤 내용을 테스트했는지/해야 하는지 -->

- [ ] 메일 조회
- [ ] 메일 수정
- [ ] 모집 활성화 상태일 때 기수 input, 지원기간 datepicker 비활성화 여부
