### PR TITLE
[FEAT]: 지원서 합격 여부 변동 API 연동

### DIFF
--- a/src/app/admin/applications/_components/table/AdminApplicationsResultDropdown.tsx
+++ b/src/app/admin/applications/_components/table/AdminApplicationsResultDropdown.tsx
@@ -12,11 +12,13 @@ import {
 interface AdminApplicationsResultDropdownProps {
   result?: ApplicationResultStatus;
   onChange?: (value: ApplicationResultStatus) => void;
+  disabled?: boolean;
 }
 
 export const AdminApplicationsResultDropdown = ({
   result = 'PENDING',
   onChange,
+  disabled,
 }: AdminApplicationsResultDropdownProps) => {
   const [selectedResult, setSelectedResult] =
     useState<ApplicationResultStatus>(result);
@@ -26,17 +28,22 @@ export const AdminApplicationsResultDropdown = ({
   const {bg, label} = APPLICATION_RESULT_CONFIG[selectedResult];
 
   const handleSelect = (value: ApplicationResultStatus) => {
+    if (value === selectedResult) {
+      setIsOpen(false);
+      return;
+    }
+
     setSelectedResult(value);
     setIsOpen(false);
     onChange?.(value);
   };
-
   useClickOutside(wrapperRef, () => setIsOpen(false));
 
   return (
     <div className='relative w-18.75' ref={wrapperRef}>
       <button
         type='button'
+        disabled={disabled}
         className={clsx(
           'inline-flex w-full items-center justify-center gap-1 rounded-[10px] py-1.5 text-body-s text-white',
           bg
@@ -61,7 +68,8 @@ export const AdminApplicationsResultDropdown = ({
                 key={option}
                 className={clsx(
                   'cursor-pointer px-3 py-1.5 text-center',
-                  isSelected ? 'text-primary' : 'hover:text-primary'
+                  isSelected ? 'text-primary' : 'hover:text-primary',
+                  disabled && 'pointer-events-none opacity-60'
                 )}
                 onClick={() => handleSelect(option)}>
                 {APPLICATION_RESULT_CONFIG[option].label}

--- a/src/app/admin/applications/_components/table/AdminApplicationsResultFilter.tsx
+++ b/src/app/admin/applications/_components/table/AdminApplicationsResultFilter.tsx
@@ -1,9 +1,8 @@
 import {RESULT_OPTIONS} from '@/constants/admin/admin-applications';
 import {ApplicationResultType} from '@/schemas/admin/admin-application-type';
-import CheckIcon from '@/assets/icons/check.svg';
-import clsx from 'clsx';
 import {RefObject, useEffect, useState} from 'react';
 import {useClickOutside} from '@/hooks/useClickOutside';
+import {Checkbox} from '@/components/checkbox/CheckBox';
 
 interface AdminApplicationsResultFilterProps {
   selected: ApplicationResultType[];
@@ -55,21 +54,20 @@ export const AdminApplicationsResultFilter = ({
         const isChecked = isAllSelected || draftSelected.includes(option);
 
         return (
-          <button
+          <div
             key={option}
-            type='button'
-            onClick={() => handleClick(option)}
             className='flex w-full items-center justify-between rounded-sm border-b border-b-neutral-600 px-2 py-1.5'>
-            <span>{option}</span>
+            <span
+              className='cursor-pointer'
+              onClick={() => handleClick(option)}>
+              {option}
+            </span>
 
-            <div
-              className={clsx(
-                'flex h-4 w-4 items-center justify-center',
-                isChecked ? 'bg-primary' : 'bg-neutral-600'
-              )}>
-              <CheckIcon />
-            </div>
-          </button>
+            <Checkbox
+              checked={isChecked}
+              onChange={() => handleClick(option)}
+            />
+          </div>
         );
       })}
 

--- a/src/app/admin/applications/_components/table/AdminApplicationsTableView.tsx
+++ b/src/app/admin/applications/_components/table/AdminApplicationsTableView.tsx
@@ -8,7 +8,10 @@ import FinishFilterIcon from '@/assets/icons/filter-finish.svg';
 import DownArrowIcon from '@/assets/arrow/down-arrow.svg';
 
 import clsx from 'clsx';
-import {ApplicantType} from '@/schemas/admin/admin-applications.schema';
+import {
+  ApplicantType,
+  ApplicationPassStatus,
+} from '@/schemas/admin/admin-applications.schema';
 import {AdminApplicationsResultDropdown} from '@/app/admin/applications/_components/table/AdminApplicationsResultDropdown';
 import {formatKoreanDate} from '@/utils/formatDate';
 
@@ -18,6 +21,11 @@ interface AdminApplicationsTableViewProps {
   isFilterActive: boolean;
   onSubmitDateSortToggle: () => void;
   onFilterToggle: () => void;
+  onChangePassStatus: (
+    applicationId: number,
+    passStatus: ApplicationPassStatus
+  ) => void;
+  isUpdating?: boolean;
 }
 
 export const AdminApplicationsTableView = ({
@@ -26,6 +34,8 @@ export const AdminApplicationsTableView = ({
   isFilterActive,
   onSubmitDateSortToggle,
   onFilterToggle,
+  onChangePassStatus,
+  isUpdating,
 }: AdminApplicationsTableViewProps) => {
   return (
     <table className='w-full table-fixed border-collapse'>
@@ -103,7 +113,13 @@ export const AdminApplicationsTableView = ({
               {formatKoreanDate(app.submittedAt)}
             </td>
             <td className='px-3 py-4'>
-              <AdminApplicationsResultDropdown result={app.passStatus} />
+              <AdminApplicationsResultDropdown
+                result={app.passStatus}
+                disabled={isUpdating}
+                onChange={(nextStatus) =>
+                  onChangePassStatus(app.applicationId, nextStatus)
+                }
+              />
             </td>
           </tr>
         ))}

--- a/src/app/admin/applications/_components/table/AdminApplicationsTableView.tsx
+++ b/src/app/admin/applications/_components/table/AdminApplicationsTableView.tsx
@@ -74,10 +74,7 @@ export const AdminApplicationsTableView = ({
                       <DownArrowIcon
                         className={clsx(
                           'transition-transform duration-200 ease-in-out',
-                          {
-                            'rotate-180': submitDateSortOrder === 'asc',
-                            'rotate-0': submitDateSortOrder === 'desc',
-                          }
+                          submitDateSortOrder === 'asc' && 'rotate-180'
                         )}
                       />
                     </button>

--- a/src/app/admin/applications/_containers/AdminApplicationsContainer.tsx
+++ b/src/app/admin/applications/_containers/AdminApplicationsContainer.tsx
@@ -14,6 +14,7 @@ export const AdminApplicationsContainer = () => {
   const router = useRouter();
 
   const statusParams = searchParams.getAll('passViewStatuses');
+  const sortDirection = searchParams.get('sort') ?? 'desc';
 
   const rawParams = {
     generationId: Number(searchParams.get('generationId') ?? 13),
@@ -21,7 +22,7 @@ export const AdminApplicationsContainer = () => {
     passViewStatuses: statusParams.length > 0 ? statusParams : ['ALL'],
     searchKeyword: searchParams.get('keyword') ?? undefined,
     page: Number(searchParams.get('page') ?? 1) - 1,
-    sort: searchParams.getAll('sort') ?? 'asc',
+    sort: `submittedAt,${sortDirection}`,
     size: 9,
   };
 

--- a/src/app/admin/applications/_containers/AdminApplicationsContainer.tsx
+++ b/src/app/admin/applications/_containers/AdminApplicationsContainer.tsx
@@ -14,7 +14,8 @@ export const AdminApplicationsContainer = () => {
   const router = useRouter();
 
   const statusParams = searchParams.getAll('passViewStatuses');
-  const sortDirection = searchParams.get('sort') ?? 'desc';
+  const sortParam = searchParams.get('sort');
+  const sortDirection = sortParam?.split(',')[1] ?? 'desc';
 
   const rawParams = {
     generationId: Number(searchParams.get('generationId') ?? 13),

--- a/src/app/admin/applications/_containers/AdminApplicationsTableContainer.tsx
+++ b/src/app/admin/applications/_containers/AdminApplicationsTableContainer.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/constants/admin/admin-applications';
 import {ApplicantsPageType} from '@/schemas/admin/admin-applications.schema';
 import {Spinner} from '@/components/ui/Spinner';
+import {useUpdateApplicationPassStatus} from '@/hooks/mutations/useAdminApplications.mutation';
 
 interface AdminApplicationsTableContainerProps {
   applicants?: ApplicantsPageType;
@@ -26,6 +27,8 @@ export const AdminApplicationsTableContainer = ({
   const passViewStatuses = searchParams.getAll('passViewStatuses');
   const submitDateSortOrder =
     searchParams.get('sort') === 'asc' ? 'asc' : 'desc';
+  const {mutate: updatePassStatus, isPending: isUpdatingPassStatus} =
+    useUpdateApplicationPassStatus();
 
   const selectedResults: ApplicationResultLabel[] =
     passViewStatuses.length === 0 || passViewStatuses.includes('ALL')
@@ -98,6 +101,13 @@ export const AdminApplicationsTableContainer = ({
               isFilterActive={isFilterActive}
               onSubmitDateSortToggle={handleSubmitDateSortToggle}
               onFilterToggle={() => setIsFilterOpen((prev) => !prev)}
+              onChangePassStatus={(applicationId, passStatus) =>
+                updatePassStatus({
+                  applicationId,
+                  body: {passStatus},
+                })
+              }
+              isUpdating={isUpdatingPassStatus}
             />
 
             {isFilterOpen && !isLoading && (

--- a/src/app/admin/applications/_containers/AdminApplicationsTableContainer.tsx
+++ b/src/app/admin/applications/_containers/AdminApplicationsTableContainer.tsx
@@ -26,7 +26,8 @@ export const AdminApplicationsTableContainer = ({
   const router = useRouter();
   const passViewStatuses = searchParams.getAll('passViewStatuses');
   const sortParam = searchParams.get('sort');
-  const submitDateSortOrder = sortParam?.endsWith(',asc') ? 'asc' : 'desc';
+  const submitDateSortOrder =
+    sortParam === 'asc' || sortParam?.endsWith(',asc') ? 'asc' : 'desc';
   const {mutate: updatePassStatus, isPending: isUpdatingPassStatus} =
     useUpdateApplicationPassStatus();
 

--- a/src/app/admin/applications/_containers/AdminApplicationsTableContainer.tsx
+++ b/src/app/admin/applications/_containers/AdminApplicationsTableContainer.tsx
@@ -25,8 +25,8 @@ export const AdminApplicationsTableContainer = ({
   const searchParams = useSearchParams();
   const router = useRouter();
   const passViewStatuses = searchParams.getAll('passViewStatuses');
-  const submitDateSortOrder =
-    searchParams.get('sort') === 'asc' ? 'asc' : 'desc';
+  const sortParam = searchParams.get('sort');
+  const submitDateSortOrder = sortParam?.endsWith(',asc') ? 'asc' : 'desc';
   const {mutate: updatePassStatus, isPending: isUpdatingPassStatus} =
     useUpdateApplicationPassStatus();
 
@@ -53,9 +53,14 @@ export const AdminApplicationsTableContainer = ({
   const handleSubmitDateSortToggle = () => {
     const params = new URLSearchParams(searchParams.toString());
 
-    const next = searchParams.get('sort') === 'desc' ? 'asc' : 'desc';
+    const currentSort = searchParams.get('sort');
 
-    params.set('sort', next);
+    const currentOrder: 'asc' | 'desc' =
+      currentSort === 'asc' || currentSort?.endsWith(',asc') ? 'asc' : 'desc';
+
+    const next: 'asc' | 'desc' = currentOrder === 'desc' ? 'asc' : 'desc';
+
+    params.set('sort', `submittedAt,${next}`);
     params.set('page', '1');
 
     router.push(`?${params.toString()}`, {scroll: false});

--- a/src/hooks/mutations/useAdminApplications.mutation.ts
+++ b/src/hooks/mutations/useAdminApplications.mutation.ts
@@ -1,0 +1,35 @@
+import {QUERY_KEYS} from '@/constants/query-keys';
+import {ApplicationPassStatus} from '@/schemas/admin/admin-applications.schema';
+import {postApplicationPassStatus} from '@/services/api/admin/admin-applications.api';
+import {useMutation, useQueryClient} from '@tanstack/react-query';
+
+/**
+ * 어드민 지원서 열람 페이지에서
+ * 특정 지원서의 합격 여부를 변경하기 위한 mutation 훅입니다.
+ *
+ * - 지원서 ID를 기준으로 합격 상태를 변경합니다.
+ * - 변경 성공 시, 지원서 목록 조회 쿼리(ADMIN_APPLICATIONS)를 무효화하여
+ *   최신 상태의 목록을 다시 조회합니다.
+ *
+ * @returns React Query mutation 객체
+ *
+ */
+export const useUpdateApplicationPassStatus = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      applicationId,
+      body,
+    }: {
+      applicationId: number;
+      body: {passStatus: ApplicationPassStatus};
+    }) => postApplicationPassStatus(applicationId, body),
+
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [QUERY_KEYS.ADMIN_APPLICATIONS],
+      });
+    },
+  });
+};

--- a/src/hooks/queries/useAdminApplications.query.ts
+++ b/src/hooks/queries/useAdminApplications.query.ts
@@ -7,6 +7,23 @@ import {getAdminApplications} from '@/services/api/admin/admin-applications.api'
 import type {ErrorResponse} from '@/schemas/common/common-schema';
 import {useQuery} from '@tanstack/react-query';
 
+/**
+ * 어드민 지원서 관리 페이지에서
+ * 지원서 목록을 조회하기 위한 React Query 훅입니다.
+ *
+ * - 페이지네이션, 정렬, 합격 상태 필터 등의 조건을 포함하여
+ *   지원서 목록을 조회합니다.
+ * - 전달된 filter 값은 queryKey에 포함되어,
+ *   필터 조건이 변경되면 자동으로 재조회됩니다.
+ *
+ * @param filter 지원서 목록 조회에 사용되는 필터 파라미터
+ * @param filter.page 페이지 번호
+ * @param filter.size 페이지당 항목 수
+ * @param filter.sort 정렬 기준 (예: 제출일 asc | desc)
+ * @param filter.passViewStatuses 합격 상태 필터 (PASS | FAIL | ALL)
+ *
+ * @returns react query
+ */
 export const useAdminApplicationsQuery = (
   filter: GetAdminApplicationsParamsType
 ) => {

--- a/src/schemas/admin/admin-applications.schema.ts
+++ b/src/schemas/admin/admin-applications.schema.ts
@@ -113,7 +113,7 @@ export const GetAdminApplicationsParamsSchema = z.object({
   searchKeyword: z.string().optional(),
   page: z.number().optional(),
   size: z.number().optional(),
-  sort: z.array(z.string()).optional(),
+  sort: z.string().optional(),
 });
 
 /**

--- a/src/services/api/admin/admin-applications.api.ts
+++ b/src/services/api/admin/admin-applications.api.ts
@@ -1,4 +1,5 @@
 import {
+  ApplicationPassStatus,
   GetAdminApplicationsParamsType,
   GetAdminApplicationsResponse,
   GetAdminApplicationsResponseSchema,
@@ -13,7 +14,6 @@ import {handleApiError} from '@/services/utils/apiHelper';
  * @param params - 필터링, 정렬, 페이지네이션 옵션 (generationId, keyword, part, sort, passViewStatuses, page)
  * @returns 지원서 목록 응답 데이터
  */
-
 export const getAdminApplications = async (
   params: GetAdminApplicationsParamsType
 ): Promise<GetAdminApplicationsResponse> => {
@@ -27,5 +27,27 @@ export const getAdminApplications = async (
     return GetAdminApplicationsResponseSchema.parse(response.data);
   } catch (error: unknown) {
     return handleApiError(error);
+  }
+};
+
+/**
+ * 지원서 합격 여부를 변경합니다.
+ * @param applicationId - 지원서 id
+ * @param body - 합/불 상태
+ * @returns null
+ */
+export const postApplicationPassStatus = async (
+  applicationId: number,
+  body: {passStatus: ApplicationPassStatus}
+) => {
+  try {
+    await privateAxios.post(
+      ENDPOINT.ADMIN.APPLICATION_PASS_STATUS(applicationId),
+      body
+    );
+
+    return null;
+  } catch (error: unknown) {
+    handleApiError(error);
   }
 };

--- a/src/services/constant/endpoint.ts
+++ b/src/services/constant/endpoint.ts
@@ -20,6 +20,8 @@ export const ENDPOINT = {
   },
   ADMIN: {
     APPLICATIONS: '/api/admin/applications',
+    APPLICATION_PASS_STATUS: (applicationId: number) =>
+      `/api/admin/application/${applicationId}/pass-status`,
     APPLICATION_QUESTIONS: '/api/admin/application-questions',
     APPLICATION_BASIC_INFO: (applicationId: number) =>
       `/api/admin/application/${applicationId}/basic-info`,


### PR DESCRIPTION
## ISSUE 🔗

<!-- ex) close #이슈번호 -->
close #62 
<br><br>

## What is this PR? 🔍

<!-- 작업 내용을 설명해 주세요 -->
어드민 지원서 열람 페이지에서 지원서 합격 여부를 변경할 수 있는 기능을 구현했습니다.

## 지원서 합격 여부 변동 API 연동 

지원서 목록 테이블에서 합격 상태(PASS / FAIL / WAITLISTED / PENDING)를 드롭다운으로 변경할 수 있습니다.
* 합격 여부 변경 시, 지원서 합격 여부 변경 API를 호출하도록 `useUpdateApplicationPassStatus` 뮤테이션 훅을 연결했습니다.
* 변경 성공 시 지원서 목록 조회 쿼리(`ADMIN_APPLICATIONS`) 키를 무효화하여, 최신 상태의 목록이 자동으로 반영되도록 처리했습니다. 

<br><br>

## Screenshot 📷

<!-- 구현된 기능/디자인 gif -->
![Animation](https://github.com/user-attachments/assets/8764803c-6def-477a-b60f-7f53b1f881cf)

<br><br>

## Test Checklist ✔

<!-- 어떤 내용을 테스트했는지/해야 하는지 -->

- [ ] 합격 변경 로직 확인!!
