### PR TITLE
[A11y]: 어드민 지원서 열람, 지원서 수정 페이지 UI 접근성 개선 (ARIA role, 키보드 포커스 대응)

### DIFF
--- a/src/app/admin/(with-sidebar)/application-edit/_components/questions/ApplicationQuestionsEdit.tsx
+++ b/src/app/admin/(with-sidebar)/application-edit/_components/questions/ApplicationQuestionsEdit.tsx
@@ -83,6 +83,7 @@ export const ApplicationQuestionsEdit = ({
               <span className='text-h5 text-neutral-500'>자</span>
             </div>
             <Button
+              aria-label={`질문 ${sequence} 삭제`}
               onClick={() => handleDelete(sequence)}
               label='삭제'
               labelTypo='body_l'
@@ -96,6 +97,7 @@ export const ApplicationQuestionsEdit = ({
         </div>
       ))}
       <FullButton
+        aria-label='지원서 질문 추가'
         label='+ 질문 추가하기'
         variant='outline'
         textColor='primary'

--- a/src/app/admin/(with-sidebar)/application-edit/_components/questions/ApplicationQuestionsView.tsx
+++ b/src/app/admin/(with-sidebar)/application-edit/_components/questions/ApplicationQuestionsView.tsx
@@ -8,17 +8,20 @@ export const ApplicationQuestionsView = ({
   data,
 }: ApplicationQuestionsViewProps) => {
   return (
-    <div className='flex flex-col gap-7.5'>
+    <ul role='list' className='flex flex-col gap-7.5'>
       {data?.map(({sequence, content, maxLength}) => (
-        <div key={sequence} className='flex flex-col gap-3.5'>
-          <div className='rounded-[10px] border border-neutral-300 bg-white px-5.25 py-4.5 text-h5 text-neutral-800'>
+        <li key={sequence} className='flex flex-col gap-3.5'>
+          <div
+            role='group'
+            aria-labelledby={`question-view-${sequence}`}
+            className='rounded-[10px] border border-neutral-300 bg-white px-5.25 py-4.5 text-h5 text-neutral-800'>
             {sequence}. {content}
           </div>
           <div className='ml-6.25 text-h5 text-neutral-400'>
             글자 제한: {maxLength} 자
           </div>
-        </div>
+        </li>
       ))}
-    </div>
+    </ul>
   );
 };

--- a/src/app/admin/(with-sidebar)/application-edit/_components/questions/ApplicationQuestionsView.tsx
+++ b/src/app/admin/(with-sidebar)/application-edit/_components/questions/ApplicationQuestionsView.tsx
@@ -15,7 +15,9 @@ export const ApplicationQuestionsView = ({
             role='group'
             aria-labelledby={`question-view-${sequence}`}
             className='rounded-[10px] border border-neutral-300 bg-white px-5.25 py-4.5 text-h5 text-neutral-800'>
-            {sequence}. {content}
+            <p id={`question-view-${sequence}`}>
+              {sequence}. {content}
+            </p>
           </div>
           <div className='ml-6.25 text-h5 text-neutral-400'>
             글자 제한: {maxLength} 자

--- a/src/app/admin/(with-sidebar)/application-edit/_containers/AdminApplicationQuestionsContainer.tsx
+++ b/src/app/admin/(with-sidebar)/application-edit/_containers/AdminApplicationQuestionsContainer.tsx
@@ -75,12 +75,18 @@ export const AdminApplicationQuestionsContainer = ({
   const isEmpty = !questions || questions.length === 0;
 
   return (
-    <>
+    <form
+      aria-labelledby='questions-form-title'
+      aria-busy={isPending}
+      className='flex flex-col gap-6'>
+      <h2 id='questions-form-title' className='sr-only'>
+        지원서 질문 관리
+      </h2>
       <div className='flex items-center justify-end'>
         {isEditing ? (
           <div className='flex flex-row items-end gap-2.25'>
             {!isFormValid && (
-              <span className='mr-1.5 text-body-m text-alert'>
+              <span role='alert' className='mr-1.5 text-body-m text-alert'>
                 모든 필드를 작성해 주세요.
               </span>
             )}
@@ -114,7 +120,7 @@ export const AdminApplicationQuestionsContainer = ({
         ) : (
           <Button
             type='button'
-            label='수정'
+            label={isEditing ? '편집 중' : '수정'}
             labelTypo='body_l'
             borderRadius={5}
             backgroundColor='secondary'
@@ -151,6 +157,6 @@ export const AdminApplicationQuestionsContainer = ({
           )}
         </div>
       </div>
-    </>
+    </form>
   );
 };

--- a/src/app/admin/(with-sidebar)/application-edit/_containers/AdminApplicationQuestionsTabContainer.tsx
+++ b/src/app/admin/(with-sidebar)/application-edit/_containers/AdminApplicationQuestionsTabContainer.tsx
@@ -20,12 +20,16 @@ export const AdminApplicationQuestionsTabContainer = () => {
   };
 
   return (
-    <div className='flex gap-12.5'>
+    <div role='tablist' aria-label='파트별 질문 선택' className='flex gap-12.5'>
       {PART_TABS.map(({label, value}) => {
         const isActive = partParam === value;
 
         return (
           <Button
+            type='button'
+            role='tab'
+            aria-selected={isActive}
+            tabIndex={isActive ? 0 : -1}
             key={value}
             label={label}
             labelTypo='h5'

--- a/src/app/admin/(with-sidebar)/application-edit/_containers/AdminRecruitmentInformationContainer.tsx
+++ b/src/app/admin/(with-sidebar)/application-edit/_containers/AdminRecruitmentInformationContainer.tsx
@@ -80,13 +80,20 @@ export const AdminRecruitmentInformationContainer = ({
   return (
     <>
       <div className='flex flex-row justify-between'>
+        <label id='generation-label' className='sr-only'>
+          기수 선택
+        </label>
         <GenerationDropdown
+          aria-labelledby='generation-label'
           generation={String(generationId)}
           generations={generations}
           onSelect={handleGenerationChange}
         />
         {isEditing ? (
-          <div className='flex flex-row gap-2.25'>
+          <div
+            role='group'
+            className='flex flex-row gap-2.25'
+            aria-label={isEditing ? '모집 정보 편집 중' : '모집 정보 조회'}>
             <Button
               label='저장'
               labelTypo='body_l'

--- a/src/app/admin/(with-sidebar)/application-edit/_containers/AdminRecruitmentInformationContainer.tsx
+++ b/src/app/admin/(with-sidebar)/application-edit/_containers/AdminRecruitmentInformationContainer.tsx
@@ -93,7 +93,7 @@ export const AdminRecruitmentInformationContainer = ({
           <div
             role='group'
             className='flex flex-row gap-2.25'
-            aria-label={isEditing ? '모집 정보 편집 중' : '모집 정보 조회'}>
+            aria-label='모집 정보 편집 중'>
             <Button
               label='저장'
               labelTypo='body_l'

--- a/src/app/admin/(with-sidebar)/applications/_components/info/AdminApplicationsInformation.tsx
+++ b/src/app/admin/(with-sidebar)/applications/_components/info/AdminApplicationsInformation.tsx
@@ -51,10 +51,14 @@ export const AdminApplicationsInformation = ({
   };
 
   return (
-    <div className='flex w-full justify-between gap-50 gap-y-4 rounded-[10px] bg-neutral-100 p-4'>
+    <div
+      className='flex w-full justify-between gap-50 gap-y-4 rounded-[10px] bg-neutral-100 p-4'
+      aria-busy={isLoading}>
       <div className='flex flex-row gap-7.25'>
         <div className='flex flex-col gap-4'>
-          <p className='text-body-l text-neutral-600'>기수 정보</p>
+          <label id='generation-label' className='text-body-l text-neutral-600'>
+            기수 정보
+          </label>
           <GenerationDropdown
             generation={generation}
             generations={generations}
@@ -62,11 +66,19 @@ export const AdminApplicationsInformation = ({
             disabled={isLoading}
           />
         </div>
-        <div className='flex flex-col gap-4'>
-          <p className='text-body-l text-neutral-600'>지원기간</p>
+        <div
+          role='group'
+          aria-labelledby='recruitment-period-label'
+          className='flex flex-col gap-4'>
+          <p
+            id='recruitment-period-label'
+            className='text-body-l text-neutral-600'>
+            지원기간
+          </p>
+
           <div className='flex flex-row gap-2.5 text-body-l font-normal'>
             {isLoading ? (
-              <Spinner size='sm' />
+              <Spinner size='sm' aria-label='지원 기간 불러오는 중' />
             ) : (
               <>
                 <p className='rounded-[10px] bg-neutral-50 px-8 py-1.75 text-neutral-800'>
@@ -81,19 +93,29 @@ export const AdminApplicationsInformation = ({
         </div>
       </div>
       <div className='flex flex-1 items-end justify-end'>
-        <div className='flex h-12.5 w-full flex-row items-center gap-2.5 rounded-[10px] bg-white px-4 py-2.75'>
-          <SearchIcon className='h-4 w-4 text-neutral-600' />
+        <form
+          role='search'
+          aria-label='지원자 검색'
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleSearch();
+          }}
+          className='flex h-12.5 w-full flex-row items-center gap-2.5 rounded-[10px] bg-white px-4 py-2.75'>
+          <SearchIcon
+            aria-hidden='true'
+            className='h-4 w-4 text-neutral-600'
+            focusable='false'
+          />
           <input
-            type='text'
+            type='search'
             placeholder='이름 혹은 학교 검색'
             aria-label='지원자 이름 또는 학교 검색'
             value={keyword}
             onChange={(e) => setKeyword(e.target.value)}
-            onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
             disabled={isLoading}
             className='w-full text-body-l font-normal outline-none placeholder:text-neutral-600'
           />
-        </div>
+        </form>
       </div>
     </div>
   );

--- a/src/app/admin/(with-sidebar)/applications/_components/info/AdminApplicationsInformation.tsx
+++ b/src/app/admin/(with-sidebar)/applications/_components/info/AdminApplicationsInformation.tsx
@@ -55,7 +55,10 @@ export const AdminApplicationsInformation = ({
       className='flex w-full justify-between gap-50 gap-y-4 rounded-[10px] bg-neutral-100 p-4'
       aria-busy={isLoading}>
       <div className='flex flex-row gap-7.25'>
-        <div className='flex flex-col gap-4'>
+        <div
+          className='flex flex-col gap-4'
+          role='group'
+          aria-labelledby='generation-label'>
           <label id='generation-label' className='text-body-l text-neutral-600'>
             기수 정보
           </label>
@@ -78,7 +81,7 @@ export const AdminApplicationsInformation = ({
 
           <div className='flex flex-row gap-2.5 text-body-l font-normal'>
             {isLoading ? (
-              <Spinner size='sm' aria-label='지원 기간 불러오는 중' />
+              <Spinner size='sm' />
             ) : (
               <>
                 <p className='rounded-[10px] bg-neutral-50 px-8 py-1.75 text-neutral-800'>

--- a/src/app/admin/(with-sidebar)/applications/_components/tab/AdminApplicationsTabPart.tsx
+++ b/src/app/admin/(with-sidebar)/applications/_components/tab/AdminApplicationsTabPart.tsx
@@ -17,6 +17,11 @@ export const AdminApplicationsTabPart = ({
   onKeyDown,
   tabIndex,
 }: AdminApplicationsTabPartProps) => {
+  const ariaLabel =
+    partName && applyNumber !== undefined
+      ? `${partName} (${applyNumber}명)`
+      : (partName ?? '파트 탭');
+
   return (
     <button
       type='button'
@@ -25,7 +30,7 @@ export const AdminApplicationsTabPart = ({
       aria-selected={isActive}
       tabIndex={tabIndex}
       onKeyDown={onKeyDown}
-      aria-label={`${partName} (${applyNumber}명)`}
+      aria-label={ariaLabel}
       className={clsx(
         'flex flex-row items-center gap-2 pb-1',
         'border-b-2 transition-colors',

--- a/src/app/admin/(with-sidebar)/applications/_components/tab/AdminApplicationsTabPart.tsx
+++ b/src/app/admin/(with-sidebar)/applications/_components/tab/AdminApplicationsTabPart.tsx
@@ -4,7 +4,9 @@ interface AdminApplicationsTabPartProps {
   partName?: string;
   applyNumber?: number;
   isActive?: boolean;
+  tabIndex?: number;
   onClick?: () => void;
+  onKeyDown?: (e: React.KeyboardEvent<HTMLElement>) => void;
 }
 
 export const AdminApplicationsTabPart = ({
@@ -12,24 +14,30 @@ export const AdminApplicationsTabPart = ({
   applyNumber,
   isActive = false,
   onClick,
+  onKeyDown,
+  tabIndex,
 }: AdminApplicationsTabPartProps) => {
   return (
     <button
       type='button'
       onClick={onClick}
+      role='tab'
+      aria-selected={isActive}
+      tabIndex={tabIndex}
+      onKeyDown={onKeyDown}
+      aria-label={`${partName} (${applyNumber}명)`}
       className={clsx(
         'flex flex-row items-center gap-2 pb-1',
         'border-b-2 transition-colors',
         isActive ? 'border-primary' : 'border-transparent'
       )}>
-      <p className='text-body-m font-bold text-neutral-800'>{partName}</p>
+      <span className='text-body-m font-bold text-neutral-800'>{partName}</span>
 
-      <div
-        className={clsx(
-          'rounded-xl bg-neutral-500 px-2 text-xs font-normal text-white'
-        )}>
+      <span
+        aria-hidden='true'
+        className='rounded-xl bg-neutral-500 px-2 text-xs font-normal text-white'>
         {applyNumber}
-      </div>
+      </span>
     </button>
   );
 };

--- a/src/app/admin/(with-sidebar)/applications/_components/table/AdminApplicationsPagination.tsx
+++ b/src/app/admin/(with-sidebar)/applications/_components/table/AdminApplicationsPagination.tsx
@@ -94,6 +94,7 @@ export const AdminApplicationsPagination = ({
                 <button
                   onClick={() => onPageChange(totalPages)}
                   disabled={disabled}
+                  aria-current={currentPage === totalPages ? 'page' : undefined}
                   className={clsx(
                     'flex h-9 w-9 items-center justify-center rounded-lg text-body-m',
                     currentPage === totalPages

--- a/src/app/admin/(with-sidebar)/applications/_components/table/AdminApplicationsPagination.tsx
+++ b/src/app/admin/(with-sidebar)/applications/_components/table/AdminApplicationsPagination.tsx
@@ -40,82 +40,87 @@ export const AdminApplicationsPagination = ({
   };
 
   return (
-    <div className='mt-6 flex items-center justify-center gap-4'>
-      <button
-        onClick={() => onPageChange(currentPage - 1)}
-        disabled={isPrevDisabled || disabled}
-        className={`flex items-center gap-3 text-body-m font-semibold ${
-          isPrevDisabled
-            ? 'cursor-not-allowed text-neutral-300'
-            : 'text-neutral-500'
-        }`}>
-        <ChevronLeft
-          className={`h-6 w-6 ${isPrevDisabled ? 'cursor-not-allowed text-neutral-300' : 'text-neutral-600'}`}
-        />
-        <p>이전</p>
-      </button>
+    <nav aria-label='지원서 페이지네이션'>
+      <div className='mt-6 flex items-center justify-center gap-4'>
+        <button
+          onClick={() => onPageChange(currentPage - 1)}
+          disabled={isPrevDisabled || disabled}
+          aria-label='이전 페이지'
+          className={`flex items-center gap-3 text-body-m font-semibold ${
+            isPrevDisabled
+              ? 'cursor-not-allowed text-neutral-300'
+              : 'text-neutral-500'
+          }`}>
+          <ChevronLeft
+            className={`h-6 w-6 ${isPrevDisabled ? 'cursor-not-allowed text-neutral-300' : 'text-neutral-600'}`}
+          />
+          <p>이전</p>
+        </button>
 
-      <div className='flex gap-2'>
-        {getVisiblePages()[0] > 1 && (
-          <span className='flex h-9 items-center px-2 text-body-m text-neutral-500'>
-            ...
-          </span>
-        )}
+        <div className='flex gap-2'>
+          {getVisiblePages()[0] > 1 && (
+            <span className='flex h-9 items-center px-2 text-body-m text-neutral-500'>
+              ...
+            </span>
+          )}
 
-        {getVisiblePages().map((page) => {
-          const isActive = page === currentPage;
+          {getVisiblePages().map((page) => {
+            const isActive = page === currentPage;
 
-          return (
-            <button
-              key={page}
-              onClick={() => onPageChange(page)}
-              disabled={disabled}
-              className={clsx(
-                'flex h-9 w-9 items-center justify-center text-body-m',
-                isActive
-                  ? 'rounded-lg border-2 border-neutral-50 bg-neutral-100 font-semibold text-neutral-600'
-                  : 'text-neutral-500'
-              )}>
-              {page}
-            </button>
-          );
-        })}
-
-        {totalPages > MAX_VISIBLE_PAGES &&
-          getVisiblePages().at(-1)! < totalPages && (
-            <>
-              <span className='flex h-9 items-center px-2 text-body-m text-neutral-500'>
-                ...
-              </span>
-
+            return (
               <button
-                onClick={() => onPageChange(totalPages)}
+                key={page}
+                onClick={() => onPageChange(page)}
+                aria-current={isActive ? 'page' : undefined}
                 disabled={disabled}
                 className={clsx(
-                  'flex h-9 w-9 items-center justify-center rounded-lg text-body-m',
-                  currentPage === totalPages
-                    ? 'bg-neutral-100 font-semibold'
-                    : 'text-neutral-600'
+                  'flex h-9 w-9 items-center justify-center text-body-m',
+                  isActive
+                    ? 'rounded-lg border-2 border-neutral-50 bg-neutral-100 font-semibold text-neutral-600'
+                    : 'text-neutral-500'
                 )}>
-                {totalPages}
+                {page}
               </button>
-            </>
-          )}
-      </div>
+            );
+          })}
 
-      <button
-        onClick={() => onPageChange(currentPage + 1)}
-        disabled={isNextDisabled || disabled}
-        className={`flex flex-row items-center gap-3 text-body-m font-semibold ${
-          isNextDisabled
-            ? 'cursor-not-allowed text-neutral-300'
-            : 'text-neutral-500'
-        }`}>
-        <p>다음</p>
-        <ChevronRight
-          className={`h-6 w-6 ${isNextDisabled ? 'text-neutral-300' : 'text-neutral-500'}`}
-        />
-      </button>
-    </div>
+          {totalPages > MAX_VISIBLE_PAGES &&
+            getVisiblePages().at(-1)! < totalPages && (
+              <>
+                <span className='flex h-9 items-center px-2 text-body-m text-neutral-500'>
+                  ...
+                </span>
+
+                <button
+                  onClick={() => onPageChange(totalPages)}
+                  disabled={disabled}
+                  className={clsx(
+                    'flex h-9 w-9 items-center justify-center rounded-lg text-body-m',
+                    currentPage === totalPages
+                      ? 'bg-neutral-100 font-semibold'
+                      : 'text-neutral-600'
+                  )}>
+                  {totalPages}
+                </button>
+              </>
+            )}
+        </div>
+
+        <button
+          onClick={() => onPageChange(currentPage + 1)}
+          disabled={isNextDisabled || disabled}
+          aria-label='다음 페이지'
+          className={`flex flex-row items-center gap-3 text-body-m font-semibold ${
+            isNextDisabled
+              ? 'cursor-not-allowed text-neutral-300'
+              : 'text-neutral-500'
+          }`}>
+          <p>다음</p>
+          <ChevronRight
+            className={`h-6 w-6 ${isNextDisabled ? 'text-neutral-300' : 'text-neutral-500'}`}
+          />
+        </button>
+      </div>
+    </nav>
   );
 };

--- a/src/app/admin/(with-sidebar)/applications/_components/table/AdminApplicationsResultDropdown.tsx
+++ b/src/app/admin/(with-sidebar)/applications/_components/table/AdminApplicationsResultDropdown.tsx
@@ -44,6 +44,8 @@ export const AdminApplicationsResultDropdown = ({
       <button
         type='button'
         disabled={disabled}
+        aria-haspopup='listbox'
+        aria-expanded={isOpen}
         className={clsx(
           'inline-flex w-full items-center justify-center gap-1 rounded-[10px] py-1.5 text-body-s text-white',
           bg
@@ -59,19 +61,31 @@ export const AdminApplicationsResultDropdown = ({
       </button>
 
       {isOpen && (
-        <ul className='absolute top-full z-10 mt-1 w-full rounded-sm bg-neutral-700 text-body-s text-neutral-300 shadow-lg'>
+        <ul
+          role='listbox'
+          aria-label='지원 결과 선택'
+          className='absolute top-full z-10 mt-1 w-full rounded-sm bg-neutral-700 text-body-s text-neutral-300 shadow-lg'>
           {APPLICATION_RESULT_OPTIONS.map((option) => {
             const isSelected = option === selectedResult;
 
             return (
               <li
                 key={option}
+                role='option'
+                aria-selected={isSelected}
+                tabIndex={0}
                 className={clsx(
                   'cursor-pointer px-3 py-1.5 text-center',
                   isSelected ? 'text-primary' : 'hover:text-primary',
                   disabled && 'pointer-events-none opacity-60'
                 )}
-                onClick={() => handleSelect(option)}>
+                onClick={() => handleSelect(option)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    handleSelect(option);
+                  }
+                }}>
                 {APPLICATION_RESULT_CONFIG[option].label}
               </li>
             );

--- a/src/app/admin/(with-sidebar)/applications/_components/table/AdminApplicationsResultDropdown.tsx
+++ b/src/app/admin/(with-sidebar)/applications/_components/table/AdminApplicationsResultDropdown.tsx
@@ -28,6 +28,7 @@ export const AdminApplicationsResultDropdown = ({
   const {bg, label} = APPLICATION_RESULT_CONFIG[selectedResult];
 
   const handleSelect = (value: ApplicationResultStatus) => {
+    if (disabled) return;
     if (value === selectedResult) {
       setIsOpen(false);
       return;
@@ -73,7 +74,7 @@ export const AdminApplicationsResultDropdown = ({
                 key={option}
                 role='option'
                 aria-selected={isSelected}
-                tabIndex={0}
+                tabIndex={isSelected ? 0 : -1}
                 className={clsx(
                   'cursor-pointer px-3 py-1.5 text-center',
                   isSelected ? 'text-primary' : 'hover:text-primary',

--- a/src/app/admin/(with-sidebar)/applications/_components/table/AdminApplicationsResultFilter.tsx
+++ b/src/app/admin/(with-sidebar)/applications/_components/table/AdminApplicationsResultFilter.tsx
@@ -45,26 +45,24 @@ export const AdminApplicationsResultFilter = ({
   };
 
   return (
-    <div className='flex flex-col gap-0.75 rounded-sm bg-neutral-700 p-1.25 text-body-s text-neutral-300'>
+    <div
+      className='flex flex-col gap-0.75 rounded-sm bg-neutral-700 p-1.25 text-body-s text-neutral-300'
+      role='group'
+      aria-label='합격 여부 필터'>
       {RESULT_OPTIONS.map((option) => {
         const isAllSelected = draftSelected.length === 0;
         const isChecked = isAllSelected || draftSelected.includes(option);
 
         return (
-          <div
+          <label
             key={option}
-            className='flex w-full items-center justify-between rounded-sm border-b border-b-neutral-600 px-2 py-1.5'>
-            <span
-              className='cursor-pointer'
-              onClick={() => handleClick(option)}>
-              {option}
-            </span>
-
+            className='flex w-full cursor-pointer items-center justify-between rounded-sm border-b border-b-neutral-600 px-2 py-1.5'>
+            <span>{option}</span>
             <Checkbox
               checked={isChecked}
               onChange={() => handleClick(option)}
             />
-          </div>
+          </label>
         );
       })}
 

--- a/src/app/admin/(with-sidebar)/applications/_components/table/AdminApplicationsTableView.tsx
+++ b/src/app/admin/(with-sidebar)/applications/_components/table/AdminApplicationsTableView.tsx
@@ -78,6 +78,8 @@ export const AdminApplicationsTableView = ({
                       <button
                         type='button'
                         onClick={onFilterToggle}
+                        aria-label='합격 여부 필터 열기'
+                        aria-expanded={isFilterOpen}
                         className='cursor-pointer'>
                         {isFilterActive ? (
                           <FinishFilterIcon />
@@ -102,7 +104,9 @@ export const AdminApplicationsTableView = ({
                     <button
                       type='button'
                       onClick={onSubmitDateSortToggle}
-                      className='cursor-pointer'>
+                      className='cursor-pointer'
+                      aria-label='제출일자 정렬 변경'
+                      aria-pressed={submitDateSortOrder === 'asc'}>
                       <DownArrowIcon
                         className={clsx(
                           'transition-transform duration-200 ease-in-out',
@@ -128,6 +132,7 @@ export const AdminApplicationsTableView = ({
                 href={`${ROUTES.ADMIN_APPLICATIONS}/${app.applicationId}?generationId=${generationId}`}
                 target='_blank'
                 rel='noopener noreferrer'
+                aria-label={`${app.name} 지원서 상세 보기`}
                 className='cursor-pointer hover:border-b'>
                 {app.name}
               </a>

--- a/src/app/admin/(with-sidebar)/applications/_containers/AdminApplicationsTabContainer.tsx
+++ b/src/app/admin/(with-sidebar)/applications/_containers/AdminApplicationsTabContainer.tsx
@@ -34,19 +34,39 @@ export const AdminApplicationsTabContainer = ({
     router.push(`?${params.toString()}`, {scroll: false});
   };
 
+  const handleKeyDown = (
+    e: React.KeyboardEvent<HTMLElement>,
+    index: number
+  ) => {
+    if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
+
+    e.preventDefault();
+
+    const nextIndex =
+      e.key === 'ArrowRight'
+        ? (index + 1) % APPLICATIONS_PART_TABS.length
+        : (index - 1 + APPLICATIONS_PART_TABS.length) %
+          APPLICATIONS_PART_TABS.length;
+
+    const nextTab = APPLICATIONS_PART_TABS[nextIndex];
+    handleTabClick(nextTab.value);
+  };
+
   return (
-    <div className='flex gap-7.5'>
-      {APPLICATIONS_PART_TABS.map(({label, value}) => {
+    <div className='flex gap-7.5' role='tablist' aria-label='지원 파트 선택'>
+      {APPLICATIONS_PART_TABS.map(({label, value}, index) => {
         const countKey = PART_COUNT_MAP[value];
         const applyNumber = summary?.[countKey];
-
+        const isActive = activePart === value;
         return (
           <AdminApplicationsTabPart
             key={value}
             partName={label}
             applyNumber={isLoading ? undefined : applyNumber}
-            isActive={activePart === value}
+            isActive={isActive}
+            tabIndex={isActive ? 0 : -1}
             onClick={() => handleTabClick(value)}
+            onKeyDown={(e) => handleKeyDown(e, index)}
           />
         );
       })}


### PR DESCRIPTION
## ISSUE 🔗

<!-- ex) close #이슈번호 -->
close #101 
<br><br>

## What is this PR? 🔍

<!-- 작업 내용을 설명해 주세요 -->
Admin 지원서 열람, 지원서 수정 페이지 전반에서 **접근성(A11y) 및 키보드 사용성 문제를 체계적으로 개선**했습니다.

기존에는 마우스 기반 사용을 전제로 한 UI 구현이 많아, 키보드만 사용하는 경우 일부 탭/드롭다운/필터/페이지네이션 요소가 정상적으로 탐색되거나 조작되지 않는 문제가 있었습니다.

본 PR에서는 다음과 같은 기준을 중심으로 개선을 진행했습니다. 

모든 작업 내용은 https://frontend-fundamentals.com/a11y/ <- 해당 문서를 참고해서 작업했습니다! 

1. **시맨틱한 역할(role) 명시**
   - 탭 구조를 가진 컴포넌트에 `role="tablist"`, `role="tab"`을 명확히 지정
   - 현재 활성 상태를 스크린 리더가 인지할 수 있도록 `aria-selected` 속성 적용

2. **키보드 포커스 흐름 정비**
   - 활성 탭만 포커스를 받을 수 있도록 `tabIndex`를 조건부로 설정
   - 비활성 탭은 `tabIndex={-1}` 처리하여 불필요한 포커스 이동 제거
   - Tab / Shift+Tab 기준으로 자연스러운 탐색 순서 보장

3. **키보드 조작 대응 확대**
   - Enter / Space 키로 버튼 및 선택 요소를 조작할 수 있도록 이벤트 동작 정비
   - 드롭다운 및 필터 컴포넌트에서 키보드만으로 열기/선택/닫기 가능하도록 개선

4. **접근성 레이블 및 상태 명확화**
   - 아이콘 버튼, 검색 input 등에 `aria-label`을 추가하여 의미 전달 강화
   - 로딩 및 비활성 상태(`disabled`)에서 포커스 및 인터랙션이 제한되도록 정리

이번 작업은 단일 컴포넌트 수정이 아닌,
Admin 페이지 내 **공통적으로 사용되는 인터랙션 컴포넌트 전반을 대상으로 한 접근성 개선**에 초점을 맞췄으니 참고해 주세요!

<br><br>

## Test Checklist ✔

<!-- 어떤 내용을 테스트했는지/해야 하는지 -->

- [x] Enter / Space 키로 탭, 버튼, 필터 선택 가능
- [x] 드롭다운 및 필터 컴포넌트가 키보드만으로 열기/선택/닫기 가능
- [x] 비활성(disabled) 상태의 요소가 포커스 및 조작 대상에서 제외됨
- [x] 아이콘 및 입력 요소에 적절한 접근성 레이블이 적용됨
- [x] 스크린 리더 환경에서 탭 및 주요 버튼의 역할과 상태가 명확히 전달됨
- [x] 탭 컴포넌트에서 활성 탭만 포커스를 가지며 `aria-selected` 상태가 정확히 반영됨
